### PR TITLE
chore(readme): bump dwm version to 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Deno Window Manager
 
 [![Tags](https://img.shields.io/github/release/deno-windowing/dwm)](https://github.com/deno-windowing/dwm/releases)
-[![Doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/dwm@0.3.0/mod.ts)
+[![Doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/dwm@0.3.3/mod.ts)
 [![Checks](https://github.com/deno-windowing/dwm/actions/workflows/ci.yml/badge.svg)](https://github.com/deno-windowing/dwm/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/deno-windowing/dwm)](https://github.com/deno-windowing/dwm/blob/master/LICENSE)
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/DjDeveloperr)
@@ -17,7 +17,7 @@ import {
   createWindow,
   getProcAddress,
   mainloop,
-} from "https://deno.land/x/dwm@0.3.0/mod.ts";
+} from "https://deno.land/x/dwm@0.3.3/mod.ts";
 import * as gl from "https://deno.land/x/gluten@0.1.3/api/gles23.2.ts";
 
 const window = createWindow({
@@ -51,7 +51,7 @@ await mainloop(frame);
 import {
   mainloop,
   WindowCanvas,
-} from "https://deno.land/x/dwm@0.3.0/ext/canvas.ts";
+} from "https://deno.land/x/dwm@0.3.3/ext/canvas.ts";
 
 const canvas = new WindowCanvas({
   title: "Skia Canvas",

--- a/src/platform/glfw/window.ts
+++ b/src/platform/glfw/window.ts
@@ -1013,7 +1013,7 @@ export class WindowGlfw extends DwmWindow {
         lockKeyMods: GLFW_LOCK_KEY_MODS,
         rawMouseMotion: GLFW_RAW_MOUSE_MOTION,
       }[mode],
-      typeof (value) === "boolean" ? value ? 1 : 0 : {
+      typeof value === "boolean" ? value ? 1 : 0 : {
         normal: GLFW_CURSOR_NORMAL,
         hidden: GLFW_CURSOR_HIDDEN,
         disabled: GLFW_CURSOR_DISABLED,


### PR DESCRIPTION
This PR fixes `Module not found` error in snippets on readme.

``` bash
hash@hashnoMacBook-Air dwm % deno run -A --unstable test.ts 
error: Module not found "https://glfw-binaries.deno.dev/3.4.0-patch1/glfw3_darwin.js".
    at https://deno.land/x/dwm@0.3.0/src/platform/glfw/ffi.ts:2:20
hash@hashnoMacBook-Air dwm % 
```